### PR TITLE
空白文字が指定されているとき、動作を停止するようにした。

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -14,6 +14,10 @@ document.getElementById('normal_action').addEventListener('click', () => {
 
 document.getElementById('designate_delete').addEventListener('click', () => {
     const designatedURL = document.getElementById('designate').value;
+    if(designatedURL === ''){
+        alert("空白を条件に指定することはできません。");
+        return;
+    }
     chrome.tabs.query({}, tabs => {
         tabs.map((currentTab) => {
             if(currentTab.url.match(designatedURL)){


### PR DESCRIPTION
#2 で述べたように、条件付き削除で空白を指定したとき、全てのタブが削除対象となる。
空白が指定されているときはアラートを出し、動作を停止するようにした。