### PR TITLE
履歴機能の実装(内部処理のみ)_やり直し

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -223,7 +223,28 @@ const deleteWhiteList = (button_element) => {
   });
 };
 
+const initHistory = () => {
+  chrome.storage.local.get('tabKillerHistory', (items) => {
+    if (items.tabKillerHistory === undefined) {
+      chrome.storage.local.set({ tabKillerHistory: [] });
+    }
+  });
+};
+
+const addHistory = (pageURL, pageTitle) => {
+  chrome.storage.local.get('tabKillerHistory', (items) => {
+    const history = items.tabKillerHistory;
+    const newElement = { URL: pageURL, title: pageTitle };
+    history.push(newElement);
+    while (history.length > 50) {
+      history.shift();
+    }
+    chrome.storage.local.set({ tabKillerHistory: history });
+  });
+};
+
 initLocalStorage();
 initWhiteList();
+initHistory();
 setDomainButton();
 addEventListeners();

--- a/src/popup.js
+++ b/src/popup.js
@@ -45,19 +45,19 @@ const addEventListeners = () => {
       alert('空白を条件に指定することはできません。');
       return;
     }
-    const newHistoryElements = [];
+    const newHistoryFactors = [];
     chrome.tabs.query(windowQuery, (tabs) => {
       tabs.map((currentTab) => {
         if (currentTab.url.match(designatedURL)) {
           chrome.tabs.remove(currentTab.id);
-          newHistoryElements.push({
+          newHistoryFactors.push({
             url: currentTab.url,
             title: currentTab.title,
           });
         }
       });
     });
-    addHistory(newHistoryElements);
+    addHistory(newHistoryFactors);
   });
 
   // domain delete tabs event
@@ -129,13 +129,13 @@ const setDomainButton = () => {
       parent.appendChild(button);
 
       document.getElementById(domain).addEventListener('click', () => {
-        const newHistoryElements = [];
+        const newHistoryFactors = [];
         chrome.tabs.query({}, (tabs) => {
           tabs.map((currentTab) => {
             const currentTabUrl = new URL(currentTab.url);
             if (currentTabUrl.hostname === domain) {
               chrome.tabs.remove(currentTab.id);
-              newHistoryElements.push({
+              newHistoryFactors.push({
                 url: currentTab.url,
                 title: currentTab.title,
               });
@@ -144,7 +144,7 @@ const setDomainButton = () => {
           // remove button
           document.getElementById(domain).remove();
         });
-        addHistory(newHistoryElements);
+        addHistory(newHistoryFactors);
       });
     }
   });
@@ -243,10 +243,10 @@ const initHistory = () => {
   });
 };
 
-const addHistory = (newHistoryElements) => {
+const addHistory = (newHistoryFactors) => {
   chrome.storage.local.get('tabKillerHistory', (items) => {
     const history = items.tabKillerHistory;
-    for (const newElement of newHistoryElements) {
+    for (const newElement of newHistoryFactors) {
       history.push(newElement);
     }
     while (history.length > 50) {

--- a/src/popup.js
+++ b/src/popup.js
@@ -49,6 +49,7 @@ const addEventListeners = () => {
       tabs.map((currentTab) => {
         if (currentTab.url.match(designatedURL)) {
           chrome.tabs.remove(currentTab.id);
+          addHistory(currentTab.url, currentTab.title);
         }
       });
     });
@@ -128,6 +129,7 @@ const setDomainButton = () => {
             const currentTabUrl = new URL(currentTab.url);
             if (currentTabUrl.hostname === domain) {
               chrome.tabs.remove(currentTab.id);
+              addHistory(currentTab.url, currentTab.title);
             }
           });
           // remove button

--- a/src/popup.js
+++ b/src/popup.js
@@ -45,14 +45,19 @@ const addEventListeners = () => {
       alert('空白を条件に指定することはできません。');
       return;
     }
+    const newHistoryElements = [];
     chrome.tabs.query(windowQuery, (tabs) => {
       tabs.map((currentTab) => {
         if (currentTab.url.match(designatedURL)) {
           chrome.tabs.remove(currentTab.id);
-          addHistory(currentTab.url, currentTab.title);
+          newHistoryElements.push({
+            url: currentTab.url,
+            title: currentTab.title,
+          });
         }
       });
     });
+    addHistory(newHistoryElements);
   });
 
   // domain delete tabs event
@@ -124,17 +129,22 @@ const setDomainButton = () => {
       parent.appendChild(button);
 
       document.getElementById(domain).addEventListener('click', () => {
+        const newHistoryElements = [];
         chrome.tabs.query({}, (tabs) => {
           tabs.map((currentTab) => {
             const currentTabUrl = new URL(currentTab.url);
             if (currentTabUrl.hostname === domain) {
               chrome.tabs.remove(currentTab.id);
-              addHistory(currentTab.url, currentTab.title);
+              newHistoryElements.push({
+                url: currentTab.url,
+                title: currentTab.title,
+              });
             }
           });
           // remove button
           document.getElementById(domain).remove();
         });
+        addHistory(newHistoryElements);
       });
     }
   });
@@ -233,11 +243,12 @@ const initHistory = () => {
   });
 };
 
-const addHistory = (pageURL, pageTitle) => {
+const addHistory = (newHistoryElements) => {
   chrome.storage.local.get('tabKillerHistory', (items) => {
     const history = items.tabKillerHistory;
-    const newElement = { URL: pageURL, title: pageTitle };
-    history.push(newElement);
+    for (const newElement of newHistoryElements) {
+      history.push(newElement);
+    }
     while (history.length > 50) {
       history.shift();
     }


### PR DESCRIPTION
solve #4

履歴初期化、削除時の履歴追加機能を実装した。

- 履歴は最大50件保持する。
- 重複タブ削除時は履歴に追加しない。(意味ないので)
- 履歴の読み出しや表示機能は実装していない。
- 履歴はchrome.storage.localに保存する。