### PR TITLE
履歴追加時に同じURLを追加しないようにした

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -45,15 +45,12 @@ const addEventListeners = () => {
       alert('空白を条件に指定することはできません。');
       return;
     }
-    const newHistoryFactors = [];
+    const newHistoryFactors = {};
     chrome.tabs.query(windowQuery, (tabs) => {
       tabs.map((currentTab) => {
         if (currentTab.url.match(designatedURL)) {
           chrome.tabs.remove(currentTab.id);
-          newHistoryFactors.push({
-            url: currentTab.url,
-            title: currentTab.title,
-          });
+          newHistoryFactors[currentTab.url] = currentTab.title;
         }
       });
     });
@@ -136,16 +133,13 @@ const setDomainButton = () => {
       parent.appendChild(button);
 
       document.getElementById(domain).addEventListener('click', () => {
-        const newHistoryFactors = [];
+        const newHistoryFactors = {};
         chrome.tabs.query({}, (tabs) => {
           tabs.map((currentTab) => {
             const currentTabUrl = new URL(currentTab.url);
             if (currentTabUrl.hostname === domain) {
               chrome.tabs.remove(currentTab.id);
-              newHistoryFactors.push({
-                url: currentTab.url,
-                title: currentTab.title,
-              });
+              newHistoryFactors[currentTab.url] = currentTab.title;
             }
           });
           // remove button
@@ -268,15 +262,13 @@ const initHistory = () => {
 
 /**
  * @param {Object} newHistoryFactors
- * @param {string} newHistoryFactors.url
- * @param {string} newHistoryFactors.title
  */
 const addHistory = (newHistoryFactors) => {
   chrome.storage.local.get('tabKillerHistory', (items) => {
     const history = items.tabKillerHistory;
-    for (const newElement of newHistoryFactors) {
-      history.push(newElement);
-    }
+    Object.keys(newHistoryFactors).map((key) => {
+      history.push({ url: key, title: newHistoryFactors[key] });
+    });
     while (history.length > 50) {
       history.shift();
     }

--- a/src/popup.js
+++ b/src/popup.js
@@ -240,6 +240,7 @@ const initHistory = () => {
   chrome.storage.local.get('tabKillerHistory', (items) => {
     if (items.tabKillerHistory === undefined) {
       chrome.storage.local.set({ tabKillerHistory: [] });
+      return;
     }
     const historyList = document.getElementById('history_list');
     historyList.innerHTML = '';


### PR DESCRIPTION
Close #40 

`key: URL, value: title`とした連想配列を用いることで履歴追加時に重複が起きないようにした。

<details>
<summary>動画</summary>

https://user-images.githubusercontent.com/60165927/139920937-49d894d5-5a64-455f-86f4-4772d3c5f6ac.mov
</details>

`initHistory`が初回起動時にエラーを吐くことに気づいたので修正した。

<details>
<summary>エラーメッセージ</summary>

![image](https://user-images.githubusercontent.com/60165927/139917898-a0e23594-7a9d-4dec-b683-833355e8b1f8.png)
</details>