### PR TITLE
tabs周りのAPIをPromiseで共通化

### DIFF
--- a/src/js/domain.js
+++ b/src/js/domain.js
@@ -31,19 +31,20 @@ export const initDomainButton = async () => {
     const parent = document.getElementById('domains');
     parent.appendChild(button);
 
-    document.getElementById(domain).addEventListener('click', () => {
+    document.getElementById(domain).addEventListener('click', async () => {
       const newHistoryFactors = {};
-      chrome.tabs.query({}, (tabs) => {
-        tabs.map((currentTab) => {
-          const currentTabUrl = new URL(currentTab.url);
-          if (currentTabUrl.hostname === domain) {
-            chrome.tabs.remove(currentTab.id);
-            newHistoryFactors[currentTab.url] = currentTab.title;
-          }
-        });
-        // remove button
-        document.getElementById(domain).remove();
+
+      const allTabs = await getAllTabs();
+      allTabs.map((currentTab) => {
+        const currentTabUrl = new URL(currentTab.url);
+        if (currentTabUrl.hostname === domain) {
+          chrome.tabs.remove(currentTab.id);
+          newHistoryFactors[currentTab.url] = currentTab.title;
+        }
       });
+      // remove button
+      document.getElementById(domain).remove();
+
       addHistory(newHistoryFactors);
     });
   }

--- a/src/js/domain.js
+++ b/src/js/domain.js
@@ -1,48 +1,50 @@
 'use strict';
 
 import { addHistory } from './history.js';
+import { getAllTabs } from './utils.js';
 
-export const initDomainButton = () => {
-  chrome.tabs.query({}, (tabs) => {
-    // extract the domains
-    const tabUrlCounter = {};
-    tabs.forEach((tab) => {
-      const url = new URL(tab.url);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        return;
-      }
-      const domain = url.hostname;
-      tabUrlCounter[domain] = (tabUrlCounter[domain] || 0) + 1;
-    });
+export const initDomainButton = async () => {
+  const allTabs = await getAllTabs();
 
-    // set button
-    const domains = Object.keys(tabUrlCounter);
-    domains.sort();
-    for (const domain of domains) {
-      const cnt = tabUrlCounter[domain];
-      const button = document.createElement('button');
-      button.className = 'button is-link is-outlined';
-      button.id = domain;
-      button.innerHTML = domain + ' (' + cnt + ')';
+  // extract the domains
+  const tabUrlCounter = {};
 
-      const parent = document.getElementById('domains');
-      parent.appendChild(button);
-
-      document.getElementById(domain).addEventListener('click', () => {
-        const newHistoryFactors = {};
-        chrome.tabs.query({}, (tabs) => {
-          tabs.map((currentTab) => {
-            const currentTabUrl = new URL(currentTab.url);
-            if (currentTabUrl.hostname === domain) {
-              chrome.tabs.remove(currentTab.id);
-              newHistoryFactors[currentTab.url] = currentTab.title;
-            }
-          });
-          // remove button
-          document.getElementById(domain).remove();
-        });
-        addHistory(newHistoryFactors);
-      });
+  allTabs.forEach((tab) => {
+    const url = new URL(tab.url);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return;
     }
+    const domain = url.hostname;
+    tabUrlCounter[domain] = (tabUrlCounter[domain] || 0) + 1;
   });
+
+  // set button
+  const domains = Object.keys(tabUrlCounter);
+  domains.sort();
+  for (const domain of domains) {
+    const cnt = tabUrlCounter[domain];
+    const button = document.createElement('button');
+    button.className = 'button is-link is-outlined';
+    button.id = domain;
+    button.innerHTML = domain + ' (' + cnt + ')';
+
+    const parent = document.getElementById('domains');
+    parent.appendChild(button);
+
+    document.getElementById(domain).addEventListener('click', () => {
+      const newHistoryFactors = {};
+      chrome.tabs.query({}, (tabs) => {
+        tabs.map((currentTab) => {
+          const currentTabUrl = new URL(currentTab.url);
+          if (currentTabUrl.hostname === domain) {
+            chrome.tabs.remove(currentTab.id);
+            newHistoryFactors[currentTab.url] = currentTab.title;
+          }
+        });
+        // remove button
+        document.getElementById(domain).remove();
+      });
+      addHistory(newHistoryFactors);
+    });
+  }
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -40,6 +40,6 @@ export const getTabsOnActiveWindow = () =>
 export const getCurrentTab = () =>
   new Promise((resolve) => {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) =>
-      resolve(tabs)
+      resolve(tabs[0])
     );
   });

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,11 +1,45 @@
 'use strict';
 
+/**
+ * @param  {string} key
+ * @return {Promise} local storage object
+ */
 export const getLocalStorage = (key = null) =>
   new Promise((resolve) => {
     chrome.storage.local.get(key, (data) => resolve(data[key]));
   });
 
+/**
+ * @param  {string} key
+ * @return {Promise} sync storage object
+ */
 export const getSyncStorage = (key = null) =>
   new Promise((resolve) => {
     chrome.storage.sync.get(key, (data) => resolve(data[key]));
+  });
+
+/**
+ * @return {Promise<Array>} All tabs
+ */
+export const getAllTabs = () =>
+  new Promise((resolve) => {
+    chrome.tabs.query({}, (tabs) => resolve(tabs));
+  });
+
+/**
+ * @return {Promise<Array>} tabs on active window
+ */
+export const getTabsOnActiveWindow = () =>
+  new Promise((resolve) => {
+    chrome.tabs.query({ currentWindow: true }, (tabs) => resolve(tabs));
+  });
+
+/**
+ * @return {Promise<Object>} current tab
+ */
+export const getCurrentTab = () =>
+  new Promise((resolve) => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) =>
+      resolve(tabs)
+    );
   });

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { getLocalStorage, getSyncStorage } from './utils.js';
+import { getCurrentTab, getLocalStorage, getSyncStorage } from './utils.js';
 
 export const setWhiteListEventListeners = () => {
   // add white list event
@@ -64,38 +64,34 @@ const addWhiteList = async () => {
   document.getElementById('white_list_input').value = '';
 };
 
-const addPresentUrlWhiteList = () => {
-  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
-    const presentURL = new URL(tabs[0].url);
+const addPresentUrlWhiteList = async () => {
+  const currentTab = await getCurrentTab();
+  const presentURL = new URL(currentTab.url);
 
-    const whiteListOnStorage =
-      (await getSyncStorage('tabKillerWhiteList')) || [];
-    const isDuplicate = whiteListOnStorage.includes(presentURL.href);
+  const whiteListOnStorage = (await getSyncStorage('tabKillerWhiteList')) || [];
+  const isDuplicate = whiteListOnStorage.includes(presentURL.href);
 
-    if (isDuplicate) {
-      alert('already exists');
-      return;
-    }
+  if (isDuplicate) {
+    alert('already exists');
+    return;
+  }
 
-    createWhiteListBadge(presentURL.href);
-    addWhiteListStorage(presentURL.href);
-  });
+  createWhiteListBadge(presentURL.href);
+  addWhiteListStorage(presentURL.href);
 };
 
-const addPresentDomainWhiteList = () => {
-  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
-    const presentURL = new URL(tabs[0].url);
+const addPresentDomainWhiteList = async () => {
+  const currentTab = await getCurrentTab();
+  const presentURL = new URL(currentTab.url);
 
-    const whiteListOnStorage =
-      (await getSyncStorage('tabKillerWhiteList')) || [];
-    const isDuplicate = whiteListOnStorage.includes(presentURL.hostname);
-    if (isDuplicate) {
-      alert('already exists');
-      return;
-    }
-    createWhiteListBadge(presentURL.hostname);
-    addWhiteListStorage(presentURL.hostname);
-  });
+  const whiteListOnStorage = (await getSyncStorage('tabKillerWhiteList')) || [];
+  const isDuplicate = whiteListOnStorage.includes(presentURL.hostname);
+  if (isDuplicate) {
+    alert('already exists');
+    return;
+  }
+  createWhiteListBadge(presentURL.hostname);
+  addWhiteListStorage(presentURL.hostname);
 };
 
 const createWhiteListBadge = (addingUrl) => {


### PR DESCRIPTION
relate: #68

参考：
https://stackoverflow.com/questions/62235131/how-to-wait-for-the-chrome-tabs-query-to-return-tab-id

`background.js`のみ未対応
これだけES6の"module"を有効化できないので、別個で対応する(issue立てました #76)
manifestを読み込むときに`.js`じゃなくて`.html`を返して読み込んであげればいけるみたい
https://medium.com/@otiai10/how-to-use-es6-import-with-chrome-extension-bd5217b9c978