### PR TITLE
auto時の確認メッセージの修正

### DIFF
--- a/src/js/history.js
+++ b/src/js/history.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { translateConfirmWord } from './language.js';
 import { getLocalStorage } from './utils.js';
 
 export const setHistoryEventListeners = () => {
@@ -80,11 +81,12 @@ const deleteHistory = async (historyFactor) => {
 };
 
 const allClear = async () => {
-  const language = (await getLocalStorage('tabKillerLanguage')) || 'ja';
-  const confirmMessage =
-    language === 'ja'
-      ? '本当にすべて削除しますか？'
-      : 'Are you sure you want to delete all history?';
+  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
+  const language =
+    languageConfig === 'auto' ? chrome.i18n.getUILanguage() : languageConfig;
+  const confirmMessage = translateConfirmWord.get('historyAllClearConfirm')[
+    language
+  ];
   const isDelete = confirm(confirmMessage);
   if (isDelete) {
     chrome.storage.local.set({ tabKillerHistory: [] });

--- a/src/js/language.js
+++ b/src/js/language.js
@@ -59,6 +59,23 @@ const placeholderIdsWord = new Map([
   ['designate', { en: 'URL keyword', ja: '消したいURL内のキーワード' }],
 ]);
 
+export const translateConfirmWord = new Map([
+  [
+    'historyAllClearConfirm',
+    {
+      en: 'Are you sure you want to delete all history?',
+      ja: '本当にすべて削除しますか？',
+    },
+  ],
+  [
+    'whiteListAllClearConfirm',
+    {
+      en: 'Are you sure you want to delete all whitelist?',
+      ja: '本当にすべて削除しますか？',
+    },
+  ],
+]);
+
 export const initLanguage = async () => {
   const languageConfigOnStorage =
     (await getLocalStorage('tabKillerLanguage')) || 'auto';

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import { translateConfirmWord } from './language.js';
 import { getCurrentTab, getLocalStorage, getSyncStorage } from './utils.js';
 
 export const setWhiteListEventListeners = () => {
@@ -131,9 +132,12 @@ const deleteWhiteList = async (buttonElement) => {
 };
 
 const allClear = async () => {
-  const language = (await getLocalStorage('tabKillerLanguage')) || 'ja';
-  const confirmMessage =
-    language === 'ja' ? '本当にすべて削除しますか？' : 'Can I delete All?';
+  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
+  const language =
+    languageConfig === 'auto' ? chrome.i18n.getUILanguage() : languageConfig;
+  const confirmMessage = translateConfirmWord.get('whiteListAllClearConfirm')[
+    language
+  ];
   const isDelete = confirm(confirmMessage);
 
   if (isDelete) {


### PR DESCRIPTION
resolve #83 

autoの判定をいれた
翻訳関係は`language.js`で管理するように統一した
この辺の翻訳とかの定数は`const.js`みたいに外出ししても良い気もする