### PR TITLE
日本語、英語以外が設定されているときの動作について改善

### DIFF
--- a/src/js/history.js
+++ b/src/js/history.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { translateConfirmWord } from './language.js';
+import { getConfirmMsg } from './language.js';
 import { getLocalStorage, setLocalStorage } from './utils.js';
 
 export const setHistoryEventListeners = () => {
@@ -86,12 +86,7 @@ const deleteHistory = async (index) => {
 };
 
 const allClear = async () => {
-  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
-  const language =
-    languageConfig === 'auto' ? chrome.i18n.getUILanguage() : languageConfig;
-  const confirmMessage = translateConfirmWord.get('historyAllClearConfirm')[
-    language
-  ];
+  const confirmMessage = await getConfirmMsg('historyAllClearConfirm');
   const isDelete = confirm(confirmMessage);
   if (isDelete) {
     setLocalStorage('tabKillerHistory', []);

--- a/src/js/language.js
+++ b/src/js/language.js
@@ -143,3 +143,19 @@ export const setLanguageEventListeners = () => {
     });
   }
 };
+
+export const getConfirmMsg = async (key) => {
+  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
+  let language = 'en';
+  if (languageConfig === 'auto') {
+    const UILanguage = chrome.i18n.getUILanguage();
+    if (UILanguage === 'en' || UILanguage === 'ja') {
+      language = UILanguage;
+    }
+  } else {
+    language = languageConfig;
+  }
+
+  const msg = translateConfirmWord.get(key)[language];
+  return msg;
+};

--- a/src/js/language.js
+++ b/src/js/language.js
@@ -77,16 +77,16 @@ export const translateConfirmWord = new Map([
 ]);
 
 export const initLanguage = async () => {
-  const languageConfigOnStorage =
-    (await getLocalStorage('tabKillerLanguage')) || 'auto';
-  document
-    .getElementById(`lang_${languageConfigOnStorage}`)
-    .classList.add('is-active');
-
-  const language =
-    languageConfigOnStorage === 'auto'
-      ? chrome.i18n.getUILanguage()
-      : languageConfigOnStorage;
+  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
+  let language = 'en';
+  if (languageConfig === 'auto') {
+    const UILanguage = chrome.i18n.getUILanguage();
+    if (UILanguage === 'en' || UILanguage === 'ja') {
+      language = UILanguage;
+    }
+  } else {
+    language = languageConfig;
+  }
 
   // translate
   translateIdWord.forEach((value, key) => {

--- a/src/js/whitelist.js
+++ b/src/js/whitelist.js
@@ -1,12 +1,7 @@
 'use strict';
 
-import { translateConfirmWord } from './language.js';
-import {
-  getCurrentTab,
-  getLocalStorage,
-  getSyncStorage,
-  setSyncStorage,
-} from './utils.js';
+import { getConfirmMsg } from './language.js';
+import { getCurrentTab, getSyncStorage, setSyncStorage } from './utils.js';
 
 export const setWhiteListEventListeners = () => {
   // add white list event
@@ -137,12 +132,7 @@ const deleteWhiteList = async (buttonElement) => {
 };
 
 const allClear = async () => {
-  const languageConfig = (await getLocalStorage('tabKillerLanguage')) || 'auto';
-  const language =
-    languageConfig === 'auto' ? chrome.i18n.getUILanguage() : languageConfig;
-  const confirmMessage = translateConfirmWord.get('whiteListAllClearConfirm')[
-    language
-  ];
+  const confirmMessage = await getConfirmMsg('whiteListAllClearConfirm');
   const isDelete = confirm(confirmMessage);
 
   if (isDelete) {


### PR DESCRIPTION
`en`, `ja`以外がUI言語に設定されている場合、`en`を使用するようにした。

(正直このあたり面倒なので言語固定モード外しませんか……？)