### PR TITLE
When delete duplicates, keep the active tab

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -38,6 +38,10 @@ const setDeleteDuplicateTabsEventListener = () => {
       const tabs = await getTabsNotInWhiteList();
       const whiteList = (await getSyncStorage('tabKillerWhiteList')) || [];
 
+      tabs.sort((a, b) => {
+        return b.active - a.active;
+      });
+
       tabs.map((currentTab, index) => {
         tabs
           .slice(index)


### PR DESCRIPTION
resolve #129 

Change the behavior when deleting duplicate tabs.
Current: Delete duplicates and keep the first tab.
New: Delete duplicates and keep the **active** tab.