### PR TITLE
重複タブ削除時の未定義動作を修正

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -38,7 +38,16 @@ const setDeleteDuplicateTabsEventListener = () => {
       const tabs = await getTabsNotInWhiteList();
 
       tabs.sort((a, b) => {
-        return b.active - a.active;
+        if (b.active > a.active) {
+          return 1;
+        } else if (b.active < a.active) {
+          return -1;
+        } else if (b.index < a.index) {
+          return 1;
+        } else if (b.index > a.index) {
+          return -1;
+        }
+        return 0;
       });
 
       const urlSet = new Set(tabs.map((tab) => tab.url));


### PR DESCRIPTION
resolve #144 

## 現在

重複タブを削除するときsortしているが、実際のタブの順番を無視している。
そのため、閉じずに残すタブが状況によって異なる。

## 提案

indexを第2キーとしてソートする。